### PR TITLE
fixing hexdump

### DIFF
--- a/SharpCifs.STD1.3/Util/Hexdump.cs
+++ b/SharpCifs.STD1.3/Util/Hexdump.cs
@@ -21,9 +21,7 @@ namespace SharpCifs.Util
 {
     public class Hexdump
     {
-        private static readonly string Nl = "\r\n"; //Runtime.GetProperty("line.separator");
-
-        private static readonly int NlLength = Nl.Length;
+        private static readonly int NlLength = Environment.NewLine.Length;
 
         private static readonly char[] SpaceChars = 
         {
@@ -106,7 +104,7 @@ namespace SharpCifs.Util
                 ci += 16;
                 c[ci++] = '|';
                 //Sharpen.Runtime.GetCharsForString(NL, 0, NL_LENGTH, c, ci);
-                Array.Copy(Nl.ToCharArray(0, NlLength), 0, c, ci, NlLength);
+                Array.Copy(Environment.NewLine.ToCharArray(0, NlLength), 0, c, ci, NlLength);
                 ci += NlLength;
             }
             while (si < length);

--- a/SharpCifs.STD1.3/Util/Hexdump.cs
+++ b/SharpCifs.STD1.3/Util/Hexdump.cs
@@ -21,7 +21,7 @@ namespace SharpCifs.Util
 {
     public class Hexdump
     {
-        private static readonly string Nl = @"\r\n"; //Runtime.GetProperty("line.separator");
+        private static readonly string Nl = "\r\n"; //Runtime.GetProperty("line.separator");
 
         private static readonly int NlLength = Nl.Length;
 
@@ -64,7 +64,7 @@ namespace SharpCifs.Util
                 return;
             }
             int s = length % 16;
-            int r = (s == 0) ? length / 16 : length / 16 + 1;
+            int r = (length + 15) / 16;
             char[] c = new char[r * (74 + NlLength)];
             char[] d = new char[16];
             int i;
@@ -106,7 +106,7 @@ namespace SharpCifs.Util
                 ci += 16;
                 c[ci++] = '|';
                 //Sharpen.Runtime.GetCharsForString(NL, 0, NL_LENGTH, c, ci);
-                c = Nl.ToCharArray(0, NlLength);
+                Array.Copy(Nl.ToCharArray(0, NlLength), 0, c, ci, NlLength);
                 ci += NlLength;
             }
             while (si < length);


### PR DESCRIPTION
Currently there are two bugs found in Util\Hexdump.cs: 
  1). incorrect constant representing newline 
  2). using string buffer assignment instead of copying.
    