### PR TITLE
Allow SocketException in socket.Endpoint

### DIFF
--- a/SharpCifs.STD1.3/Smb/SmbTransport.cs
+++ b/SharpCifs.STD1.3/Smb/SmbTransport.cs
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO;c
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -520,7 +520,6 @@ namespace SharpCifs.Smb
             }
         }
 
-        /// <exception cref="SharpCifs.Smb.SmbException"></exception>
         public virtual void Connect()
         {
             try
@@ -529,9 +528,19 @@ namespace SharpCifs.Smb
             }
             catch (TransportException te)
             {
-                var local = (IPEndPoint)this.Socket?.LocalEndPoint;
-                var remote = (IPEndPoint)this.Socket?.RemoteEndPoint;
-                
+                IPEndPoint local = null;
+                IPEndPoint remote = null;
+
+                try
+                {
+                    local = (IPEndPoint)this.Socket?.LocalEndPoint;
+                    remote = (IPEndPoint)this.Socket?.RemoteEndPoint;
+                }
+                catch (SocketException)
+                {
+
+                }
+
                 // IO Exception
                 throw new SmbException($"Failed to connect, {Address}  [ {local?.Address}:{local?.Port} --> {remote?.Address}:{remote?.Port} ]", te);
             }

--- a/SharpCifs.STD1.3/Smb/SmbTransport.cs
+++ b/SharpCifs.STD1.3/Smb/SmbTransport.cs
@@ -520,6 +520,7 @@ namespace SharpCifs.Smb
             }
         }
 
+        /// <exception cref="SharpCifs.Smb.SmbException"></exception>
         public virtual void Connect()
         {
             try

--- a/SharpCifs.STD1.3/Smb/SmbTransport.cs
+++ b/SharpCifs.STD1.3/Smb/SmbTransport.cs
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 using System;
 using System.Collections.Generic;
-using System.IO;c
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;


### PR DESCRIPTION
# Problem

We've only recently been using the software and this problem popped up multiple times. It appears that an exception occurs while trying to rethrow and handle another exception. This causes the sockets to not be cleaned up properly and (in our case) Tasks to run indefinitely.



## Chosen solution

This PR allows the `Socket.RemoteEndPoint` and `Socket.LocalEndPoint` properties to throw a `SocketException` . I've chosen this solution as it appears that both the `local` and `remote ` variable were allowed to be `null`



### Background Info

Below is the stacktrace of the situation as described

```
System.Net.Sockets.SocketException (107): Transport endpoint is not connected
   at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, String callerName)
   at System.Net.Sockets.Socket.get_RemoteEndPoint()
   at SharpCifs.Smb.SmbTransport.Connect()
   at SharpCifs.Smb.SmbTree.TreeConnect(ServerMessageBlock andx, ServerMessageBlock andxResponse)
   at SharpCifs.Smb.SmbFile.DoConnect()
   at SharpCifs.Smb.SmbFile.Connect()
   at SharpCifs.Smb.SmbFile.Connaect0()
   at SharpCifs.Smb.SmbFile.ResolveDfs(ServerMessageBlock request)
   at SharpCifs.Smb.SmbFile.Send(ServerMessageBlock request, ServerMessageBlock response)
   at SharpCifs.Smb.SmbFile.DoFindFirstNext(List`1 list, Boolean files, String wildcard, Int32 searchAttributes, ISmbFilenameFilter fnf, ISmbFileFilter ff)
   at SharpCifs.Smb.SmbFile.DoEnum(List`1 list, Boolean files, String wildcard, Int32 searchAttributes, ISmbFilenameFilter fnf, ISmbFileFilter ff)
   at SharpCifs.Smb.SmbFile.List(String wildcard, Int32 searchAttributes, ISmbFilenameFilter fnf, ISmbFileFilter ff)
```