### PR TITLE
Use ToArray() in ClearCachedConnections to prevent InvalidOperationEx…

### DIFF
--- a/SharpCifs.STD1.3/Smb/SmbTransport.cs
+++ b/SharpCifs.STD1.3/Smb/SmbTransport.cs
@@ -97,7 +97,7 @@ namespace SharpCifs.Smb
             {
                 var failedTransport = new List<SmbTransport>();
 
-                foreach (var transport in SmbConstants.Connections)
+                foreach (var transport in SmbConstants.Connections.ToArray())
                 {
                     //強制破棄フラグONのとき、接続状態がどうであれ破棄する。
                     if (force)


### PR DESCRIPTION
Use ToArray() in ClearCachedConnections to prevent InvalidOperationExceptions being raised from removing items from the collection used by the foreach loop. Credit gcamp806. This fixes #40 